### PR TITLE
Extend BackendPipelineDispatcher to take multiple Labels

### DIFF
--- a/nexuse2e-core/src/main/java/org/nexuse2e/backend/BackendPipelineDispatcher.java
+++ b/nexuse2e-core/src/main/java/org/nexuse2e/backend/BackendPipelineDispatcher.java
@@ -22,8 +22,10 @@ package org.nexuse2e.backend;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.StringTokenizer;
 
 import org.apache.commons.lang.StringUtils;
@@ -159,7 +161,7 @@ public class BackendPipelineDispatcher implements Manageable, InitializingBean {
      * @param actionId
      * @param conversationId
      * @param messageId
-     * @param label
+     * @param label A single label. The format is {@code <KEY>|<VALUE>}.
      * @param primaryKey
      * @param payloads A list of Objects that can be either of type <code>byte[]</code> or {@link MessagePayloadPojo}.
      *                  The elements must not necessarily be all of the same type. 
@@ -170,152 +172,169 @@ public class BackendPipelineDispatcher implements Manageable, InitializingBean {
     public MessageContext processMessage( String partnerId, String choreographyId, String actionId,
             String conversationId, String messageId, String label, Object primaryKey, List<? extends Object> payloads,
             List<ErrorDescriptor> errors ) throws NexusException {
-        
-        String contentId = null;
-
-        if ( choreographyId == null || choreographyId.trim().equals( "" ) ) {
-            throw new NexusException( "No valid choreography found for ID: " + choreographyId );
-        }
-        if ( actionId == null || actionId.trim().equals( "" ) ) {
-            throw new NexusException( "No valid action found for ID: " + actionId );
-        }
-
-        ActionSpecificKey key = new ActionSpecificKey( actionId, choreographyId );
-
-        BackendPipeline pipeline = pipelines.get( key );
-
-        if ( pipeline == null ) {
-            if ( LOG.isDebugEnabled() ) {
-                LOG.debug(new LogMessage(  "pipelines.size: " + pipelines.size(),conversationId,messageId) );
-                for ( ActionSpecificKey actionSpecificKey : pipelines.keySet() ) {
-                    LOG.debug(new LogMessage(  "PipelineKey: " + actionSpecificKey + " - " + pipelines.get( actionSpecificKey ),conversationId,messageId) );
-                }
-            }
-            throw new NexusException( "no matching pipeline found for choreography:" + choreographyId + " and Action:"
-                    + actionId );
-        }
-
-        MessageContext messageContext = new MessageContext();
-        messageContext.setActionSpecificKey( key );
-
-        if ( messageId == null || messageId.equals( "" ) ) {
-            IdGenerator messageIdGenerator = Engine.getInstance().getIdGenerator(
-                    Constants.ID_GENERATOR_MESSAGE );
-            messageId = messageIdGenerator.getId();
-        }
-
-        if ( conversationId == null || conversationId.equals( "" ) ) {
-            IdGenerator conversationIdGenerator = Engine.getInstance().getIdGenerator(
-                    Constants.ID_GENERATOR_CONVERSATION );
-            conversationId = conversationIdGenerator.getId();
-        }
-
-        MessagePojo messagePojo = Engine.getInstance().getTransactionService().createMessage( messageId,
-                conversationId, actionId, partnerId, choreographyId,
-                org.nexuse2e.messaging.Constants.INT_MESSAGE_TYPE_NORMAL );
-        messagePojo.setOutbound( true );
-
-        if ( !StringUtils.isEmpty( label ) && ( label.indexOf( "|" ) != -1 ) ) {
+        Map<String, String> labels = new HashMap<>(1);
+        if (label != null && label.contains("|")) {
             StringTokenizer st = new StringTokenizer( label, "|" );
-            String name = st.nextToken();
-            String value = st.nextToken();
-            contentId = value;
-            
-            if ( org.nexuse2e.Constants.NX_LABEL_FILE_NAME.equals( name ) ) {
-                MessageLabelPojo messageLabelPojo = new MessageLabelPojo( messagePojo,
-                        new Date(), new Date(), 1, name, value );
-                List<MessageLabelPojo> messageLabels = messagePojo.getMessageLabels();
-                if ( messageLabels == null ) {
-                    messageLabels = new ArrayList<MessageLabelPojo>();
-                    messageContext.getMessagePojo().setMessageLabels( messageLabels );
-                }
-                messageLabels.add( messageLabelPojo );
-            }
+            labels = new HashMap<>(1);
+            labels.put(st.nextToken(), st.nextToken());
         }
+        return processMessage( partnerId, choreographyId, actionId, conversationId, messageId, labels,
+                primaryKey, payloads, errors );
+    } // processMessage
 
-        messageContext.setConversation( messagePojo.getConversation() );
+    /**
+     * @param partnerId
+     * @param choreographyId
+     * @param actionId
+     * @param conversationId
+     * @param messageId
+     * @param label
+     * @param primaryKey
+     * @param payloads A list of Objects that can be either of type <code>byte[]</code> or {@link MessagePayloadPojo}.
+     *                  The elements must not necessarily be all of the same type. 
+     * @param errors
+     * @return
+     * @throws NexusException
+     */
+    public MessageContext processMessage( String partnerId, String choreographyId, String actionId,
+          String conversationId, String messageId, Map<String, String> labels, Object primaryKey,
+          List<? extends Object> payloads, List<ErrorDescriptor> errors ) throws NexusException {
+       String contentId = null;
 
-        // Set conversation on MessageContext
-        if ( primaryKey != null ) {
-            messageContext.setData( primaryKey );
-        }
-        
-        // payload handling > detect type > only set values, if empty yet
-        List<MessagePayloadPojo> payloadPojos = new ArrayList<MessagePayloadPojo>();
-        if ( payloads != null ) {
-            int payloadIndex = 1;
-            for ( Object currPayload : payloads ) {
-                MessagePayloadPojo messagePayloadPojo = null;
-                if ( currPayload instanceof byte[] ) {
-                    byte[] payloadData = (byte[]) currPayload;
-                    if ( payloadData != null && payloadData.length > 0 ) {
-                        messagePayloadPojo = new MessagePayloadPojo();
-                        messagePayloadPojo.setPayloadData( payloadData );
-                    }
-                } else if ( currPayload instanceof MessagePayloadPojo ) {
-                    messagePayloadPojo = (MessagePayloadPojo) currPayload;
-                } else {
-                    throw new NexusException( "Invalid payload type detected. Must be either of type byte[] or MessagePayloadPojo." );
-                }
-                
-                payloadPojos.add( messagePayloadPojo );
-                
-                // init payload pojo
-                messagePayloadPojo.setMessage( messagePojo );
-                if ( StringUtils.isEmpty( messagePayloadPojo.getMimeType() ) ) {
+       if ( choreographyId == null || choreographyId.trim().equals( "" ) ) {
+           throw new NexusException( "No valid choreography found for ID: " + choreographyId );
+       }
+       if ( actionId == null || actionId.trim().equals( "" ) ) {
+           throw new NexusException( "No valid action found for ID: " + actionId );
+       }
+
+       ActionSpecificKey key = new ActionSpecificKey( actionId, choreographyId );
+
+       BackendPipeline pipeline = pipelines.get( key );
+
+       if ( pipeline == null ) {
+           if ( LOG.isDebugEnabled() ) {
+               LOG.debug(new LogMessage(  "pipelines.size: " + pipelines.size(),conversationId,messageId) );
+               for ( ActionSpecificKey actionSpecificKey : pipelines.keySet() ) {
+                   LOG.debug(new LogMessage(  "PipelineKey: " + actionSpecificKey + " - " + pipelines.get( actionSpecificKey ),conversationId,messageId) );
+               }
+           }
+           throw new NexusException( "no matching pipeline found for choreography:" + choreographyId + " and Action:"
+                   + actionId );
+       }
+
+       MessageContext messageContext = new MessageContext();
+       messageContext.setActionSpecificKey( key );
+
+       if ( messageId == null || messageId.equals( "" ) ) {
+           IdGenerator messageIdGenerator = Engine.getInstance().getIdGenerator(
+                   Constants.ID_GENERATOR_MESSAGE );
+           messageId = messageIdGenerator.getId();
+       }
+
+       if ( conversationId == null || conversationId.equals( "" ) ) {
+           IdGenerator conversationIdGenerator = Engine.getInstance().getIdGenerator(
+                   Constants.ID_GENERATOR_CONVERSATION );
+           conversationId = conversationIdGenerator.getId();
+       }
+
+       MessagePojo messagePojo = Engine.getInstance().getTransactionService().createMessage( messageId,
+               conversationId, actionId, partnerId, choreographyId,
+               org.nexuse2e.messaging.Constants.INT_MESSAGE_TYPE_NORMAL );
+       messagePojo.setOutbound( true );
+
+       Date now = new Date();
+       for ( Entry<String, String> entry : labels.entrySet() ) {
+           MessageLabelPojo label = new MessageLabelPojo( messagePojo, now, now, 1, entry.getKey(), entry.getValue() );
+           if ( messagePojo.getMessageLabels() == null ) {
+               messagePojo.setMessageLabels( new ArrayList<MessageLabelPojo>() );
+           }
+           messagePojo.getMessageLabels().add( label );
+       }
+
+       messageContext.setConversation( messagePojo.getConversation() );
+
+       // Set conversation on MessageContext
+       if ( primaryKey != null ) {
+           messageContext.setData( primaryKey );
+       }
+       
+       // payload handling > detect type > only set values, if empty yet
+       List<MessagePayloadPojo> payloadPojos = new ArrayList<MessagePayloadPojo>();
+       if ( payloads != null ) {
+           int payloadIndex = 1;
+           for ( Object currPayload : payloads ) {
+               MessagePayloadPojo messagePayloadPojo = null;
+               if ( currPayload instanceof byte[] ) {
+                   byte[] payloadData = (byte[]) currPayload;
+                   if ( payloadData != null && payloadData.length > 0 ) {
+                       messagePayloadPojo = new MessagePayloadPojo();
+                       messagePayloadPojo.setPayloadData( payloadData );
+                   }
+               } else if ( currPayload instanceof MessagePayloadPojo ) {
+                   messagePayloadPojo = (MessagePayloadPojo) currPayload;
+               } else {
+                   throw new NexusException( "Invalid payload type detected. Must be either of type byte[] or MessagePayloadPojo." );
+               }
+               
+               payloadPojos.add( messagePayloadPojo );
+               
+               // init payload pojo
+               messagePayloadPojo.setMessage( messagePojo );
+               if ( StringUtils.isEmpty( messagePayloadPojo.getMimeType() ) ) {
 					String mimetype = null;
-                	try {
+               	try {
 						ContentHandler contenthandler = new BodyContentHandler();
 						Metadata metadata = new Metadata();
 						Parser parser = new AutoDetectParser();
 						ByteArrayInputStream bias = new ByteArrayInputStream( messagePayloadPojo.getPayloadData() );
-                        parser.parse( bias, contenthandler, metadata, null );
-                        // TODO: Fix this (text/xml is detected as text/html)
-                        mimetype = metadata.get( Metadata.CONTENT_TYPE );
-                        if ("text/html".equals(mimetype)) {
-                            mimetype = "text/xml";
-                        }
-                        LOG.trace(new LogMessage("autodetermined mimetype: "+mimetype,messageContext));
-                        if(!Engine.getInstance().isBinaryType( mimetype )) {
-                            CharsetDetector detector = new CharsetDetector();
-                            detector.setText( messagePayloadPojo.getPayloadData() );
-                        }
-                    } catch ( Exception e ) {
-                        throw new NexusException( new LogMessage( "mime detection failed: "+e.getMessage(),messageContext),e);
+                       parser.parse( bias, contenthandler, metadata, null );
+                       // TODO: Fix this (text/xml is detected as text/html)
+                       mimetype = metadata.get( Metadata.CONTENT_TYPE );
+                       if ("text/html".equals(mimetype)) {
+                           mimetype = "text/xml";
+                       }
+                       LOG.trace(new LogMessage("autodetermined mimetype: "+mimetype,messageContext));
+                       if(!Engine.getInstance().isBinaryType( mimetype )) {
+                           CharsetDetector detector = new CharsetDetector();
+                           detector.setText( messagePayloadPojo.getPayloadData() );
+                       }
+                   } catch ( Exception e ) {
+                       throw new NexusException( new LogMessage( "mime detection failed: "+e.getMessage(),messageContext),e);
 					} 
-                	messagePayloadPojo.setMimeType(mimetype );
-                }
-                if ( StringUtils.isEmpty( messagePayloadPojo.getContentId() ) ) {
-                    if ( StringUtils.isEmpty( contentId ) ) {
-                        messagePayloadPojo.setContentId( messagePojo.getMessageId() + "__body" + payloadIndex );
-                    } else {
-                        messagePayloadPojo.setContentId( contentId + "__body_" + payloadIndex );
-                    }
-                }
-                messagePayloadPojo.setSequenceNumber( new Integer( payloadIndex ) );
-                messagePayloadPojo.setCreatedDate( messagePojo.getCreatedDate() );
-                messagePayloadPojo.setModifiedDate( messagePojo.getCreatedDate() );
-                payloadIndex++;
-            }
-        }
-        // attach payloads to message
-        messagePojo.setMessagePayloads( payloadPojos );
+               	messagePayloadPojo.setMimeType(mimetype );
+               }
+               if ( StringUtils.isEmpty( messagePayloadPojo.getContentId() ) ) {
+                   if ( StringUtils.isEmpty( contentId ) ) {
+                       messagePayloadPojo.setContentId( messagePojo.getMessageId() + "__body" + payloadIndex );
+                   } else {
+                       messagePayloadPojo.setContentId( contentId + "__body_" + payloadIndex );
+                   }
+               }
+               messagePayloadPojo.setSequenceNumber( new Integer( payloadIndex ) );
+               messagePayloadPojo.setCreatedDate( messagePojo.getCreatedDate() );
+               messagePayloadPojo.setModifiedDate( messagePojo.getCreatedDate() );
+               payloadIndex++;
+           }
+       }
+       // attach payloads to message
+       messagePojo.setMessagePayloads( payloadPojos );
 
-        if ( errors != null ) {
-            messagePojo.setErrors( errors );
-        }
+       if ( errors != null ) {
+           messagePojo.setErrors( errors );
+       }
 
-        messageContext.setMessagePojo( messagePojo );
-        try {
-            pipeline.processMessage( messageContext );
-        } catch ( NexusException e ) {
-            throw e;
-        } catch ( Error e ) {
-            throw new NexusException( e.toString() );
-        }
+       messageContext.setMessagePojo( messagePojo );
+       try {
+           pipeline.processMessage( messageContext );
+       } catch ( NexusException e ) {
+           throw e;
+       } catch ( Error e ) {
+           throw new NexusException( e.toString() );
+       }
 
-        return messageContext;
-    } // processMessage
+       return messageContext;
+    }
 
     /* (non-Javadoc)
      * @see org.nexuse2e.Manageable#initialize()


### PR DESCRIPTION
The BackendPipelineDispatcher only accepted a single
label in the form KEY|VALUE. It also ignored
the passed label if the KEY was anything else
than _nxFileName.

This commit overloads the method to pass a Map.
Thus allowing multiple labels. It also removes
the restriction on the label KEY.

I was not able to run the tests because the build ran into the following error
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.731 s
[INFO] Finished at: 2020-02-17T12:06:47+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.cxf:cxf-codegen-plugin:2.3.2:wsdl2java (generate-aggateway-ws) on project nexuse2e-core: Execution generate-aggateway-ws of goal org.apache.cxf:cxf-codegen-plugin:2.3.2:wsdl2java failed: A required class was missing while executing org.apache.cxf:cxf-codegen-plugin:2.3.2:wsdl2java: javax/xml/bind/JAXBException
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.cxf:cxf-codegen-plugin:2.3.2
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-codegen-plugin/2.3.2/cxf-codegen-plugin-2.3.2.jar
[ERROR] urls[1] = file:/home/serra/.m2/repository/xerces/xercesImpl/2.8.1/xercesImpl-2.8.1.jar
[ERROR] urls[2] = file:/home/serra/.m2/repository/org/apache/maven/shared/maven-artifact-resolver/1.0/maven-artifact-resolver-1.0.jar
[ERROR] urls[3] = file:/home/serra/.m2/repository/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
[ERROR] urls[4] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-tools-common/2.3.2/cxf-tools-common-2.3.2.jar
[ERROR] urls[5] = file:/home/serra/.m2/repository/org/apache/velocity/velocity/1.6.4/velocity-1.6.4.jar
[ERROR] urls[6] = file:/home/serra/.m2/repository/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar
[ERROR] urls[7] = file:/home/serra/.m2/repository/commons-lang/commons-lang/2.5/commons-lang-2.5.jar
[ERROR] urls[8] = file:/home/serra/.m2/repository/oro/oro/2.0.8/oro-2.0.8.jar
[ERROR] urls[9] = file:/home/serra/.m2/repository/wsdl4j/wsdl4j/1.6.2/wsdl4j-1.6.2.jar
[ERROR] urls[10] = file:/home/serra/.m2/repository/com/sun/xml/bind/jaxb-xjc/2.1.13/jaxb-xjc-2.1.13.jar
[ERROR] urls[11] = file:/home/serra/.m2/repository/com/sun/xml/bind/jaxb-impl/2.1.13/jaxb-impl-2.1.13.jar
[ERROR] urls[12] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-api/2.3.2/cxf-api-2.3.2.jar
[ERROR] urls[13] = file:/home/serra/.m2/repository/org/apache/neethi/neethi/2.0.4/neethi-2.0.4.jar
[ERROR] urls[14] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-rt-core/2.3.2/cxf-rt-core-2.3.2.jar
[ERROR] urls[15] = file:/home/serra/.m2/repository/org/apache/geronimo/specs/geronimo-javamail_1.4_spec/1.7.1/geronimo-javamail_1.4_spec-1.7.1.jar
[ERROR] urls[16] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-tools-wsdlto-core/2.3.2/cxf-tools-wsdlto-core-2.3.2.jar
[ERROR] urls[17] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-tools-validator/2.3.2/cxf-tools-validator-2.3.2.jar
[ERROR] urls[18] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-common-schemas/2.3.2/cxf-common-schemas-2.3.2.jar
[ERROR] urls[19] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-common-utilities/2.3.2/cxf-common-utilities-2.3.2.jar
[ERROR] urls[20] = file:/home/serra/.m2/repository/org/apache/ws/commons/schema/XmlSchema/1.4.7/XmlSchema-1.4.7.jar
[ERROR] urls[21] = file:/home/serra/.m2/repository/org/codehaus/woodstox/woodstox-core-asl/4.0.8/woodstox-core-asl-4.0.8.jar
[ERROR] urls[22] = file:/home/serra/.m2/repository/org/codehaus/woodstox/stax2-api/3.0.2/stax2-api-3.0.2.jar
[ERROR] urls[23] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-tools-wsdlto-databinding-jaxb/2.3.2/cxf-tools-wsdlto-databinding-jaxb-2.3.2.jar
[ERROR] urls[24] = file:/home/serra/.m2/repository/org/apache/cxf/cxf-tools-wsdlto-frontend-jaxws/2.3.2/cxf-tools-wsdlto-frontend-jaxws-2.3.2.jar
[ERROR] urls[25] = file:/home/serra/.m2/repository/xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar
[ERROR] urls[26] = file:/home/serra/.m2/repository/org/springframework/spring-core/3.0.5.RELEASE/spring-core-3.0.5.RELEASE.jar
[ERROR] urls[27] = file:/home/serra/.m2/repository/org/springframework/spring-asm/3.0.5.RELEASE/spring-asm-3.0.5.RELEASE.jar
[ERROR] urls[28] = file:/home/serra/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar
[ERROR] urls[29] = file:/home/serra/.m2/repository/org/springframework/spring-beans/3.0.5.RELEASE/spring-beans-3.0.5.RELEASE.jar
[ERROR] urls[30] = file:/home/serra/.m2/repository/org/springframework/spring-context/3.0.5.RELEASE/spring-context-3.0.5.RELEASE.jar
[ERROR] urls[31] = file:/home/serra/.m2/repository/org/springframework/spring-aop/3.0.5.RELEASE/spring-aop-3.0.5.RELEASE.jar
[ERROR] urls[32] = file:/home/serra/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar
[ERROR] urls[33] = file:/home/serra/.m2/repository/org/springframework/spring-expression/3.0.5.RELEASE/spring-expression-3.0.5.RELEASE.jar
[ERROR] urls[34] = file:/home/serra/.m2/repository/org/apache/ant/ant/1.8.1/ant-1.8.1.jar
[ERROR] urls[35] = file:/home/serra/.m2/repository/org/apache/ant/ant-launcher/1.8.1/ant-launcher-1.8.1.jar
[ERROR] urls[36] = file:/home/serra/.m2/repository/org/apache/ant/ant-nodeps/1.8.1/ant-nodeps-1.8.1.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------
[ERROR] : javax.xml.bind.JAXBException
```