### PR TITLE
Upgrade cxf-codegen-plugin

### DIFF
--- a/nexuse2e-core/pom.xml
+++ b/nexuse2e-core/pom.xml
@@ -736,7 +736,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-codegen-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.3.5</version>
 
                 <dependencies>
 


### PR DESCRIPTION
The cfx-codegen-plugin uses the jaxb classes
to do its work.

Newer jdk's removed those classes since they
were no part of the JavaSE API in the first
places.

Applications depending on it need to provide
the classes themself which is exactly what
newer versions of this plugin do.