### PR TITLE
Fix wrong method call

### DIFF
--- a/nexuse2e-core/src/main/java/org/nexuse2e/backend/BackendPipelineDispatcher.java
+++ b/nexuse2e-core/src/main/java/org/nexuse2e/backend/BackendPipelineDispatcher.java
@@ -178,7 +178,7 @@ public class BackendPipelineDispatcher implements Manageable, InitializingBean {
             labels = new HashMap<>(1);
             labels.put(st.nextToken(), st.nextToken());
         }
-        return processMessage( partnerId, choreographyId, actionId, conversationId, messageId, labels,
+        return processMessageWithLabels( partnerId, choreographyId, actionId, conversationId, messageId, labels,
                 primaryKey, payloads, errors );
     } // processMessage
 


### PR DESCRIPTION
Since 3fd082adb232d8a43087f40b6c50911e9b250077 the
specified method does not exist anymore due to a rename.

Fix the method call to make the code compile again.