### PR TITLE
Use filename for contentId

### DIFF
--- a/nexuse2e-core/src/main/java/org/nexuse2e/backend/BackendPipelineDispatcher.java
+++ b/nexuse2e-core/src/main/java/org/nexuse2e/backend/BackendPipelineDispatcher.java
@@ -249,6 +249,9 @@ public class BackendPipelineDispatcher implements Manageable, InitializingBean {
                 messagePojo.setMessageLabels(new ArrayList<MessageLabelPojo>());
             }
             messagePojo.getMessageLabels().add(label);
+            if (entry.getKey().equals(org.nexuse2e.Constants.NX_LABEL_FILE_NAME)) {
+                contentId = entry.getValue();
+            }
         }
 
         messageContext.setConversation(messagePojo.getConversation());


### PR DESCRIPTION
Fixes a bug introduced in an earlier commit. The filename is used as contentId if a label for the filename exists.