### PR TITLE
11505 update permissions on site reload

### DIFF
--- a/nexuse2e-webapp/src/main/frontend/src/app/app.component.ts
+++ b/nexuse2e-webapp/src/main/frontend/src/app/app.component.ts
@@ -1,19 +1,24 @@
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { TranslateService } from "@ngx-translate/core";
 import { LoginComponent } from "./login/login.component";
 import { PageNotFoundComponent } from "./page-not-found/page-not-found.component";
+import { PermissionService } from "./services/permission.service";
 
 @Component({
   selector: "app-root",
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   showHeaderNav = false;
   navExpanded = false;
 
-  constructor(translate: TranslateService) {
+  constructor(translate: TranslateService, private permissionService: PermissionService) {
     translate.use("en");
+  }
+
+  ngOnInit() {
+    this.permissionService.updatePermissions();
   }
 
   // eslint-disable-next-line

--- a/nexuse2e-webapp/src/main/frontend/src/app/login/login.component.ts
+++ b/nexuse2e-webapp/src/main/frontend/src/app/login/login.component.ts
@@ -2,7 +2,7 @@ import { Component, Injectable, OnInit } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { DataService } from "../services/data.service";
 import { NavigationService } from "../navigation/navigation.service";
-import { SessionService } from "../services/session.service";
+import { PermissionService } from "../services/permission.service";
 
 interface LoginData {
   user: string;
@@ -27,7 +27,7 @@ export class LoginComponent implements OnInit {
     private router: Router,
     private dataService: DataService,
     private navigationService: NavigationService,
-    private sessionService: SessionService
+    private permissionService: PermissionService
   ) {}
 
   async ngOnInit() {
@@ -58,12 +58,8 @@ export class LoginComponent implements OnInit {
 
   async login(loginData: LoginData) {
     await this.dataService.postLogin(loginData);
-
-    const permittedActions = await this.dataService.getPermittedActions();
-    this.sessionService.setPermittedActions(permittedActions);
-
+    this.permissionService.updatePermissions();
     this.navigationService.hideNavigation();
-
     const returnUrl = this.route.snapshot.queryParams["returnUrl"] || "/";
     await this.router.navigateByUrl(returnUrl);
   }

--- a/nexuse2e-webapp/src/main/frontend/src/app/services/permission.service.ts
+++ b/nexuse2e-webapp/src/main/frontend/src/app/services/permission.service.ts
@@ -1,12 +1,18 @@
 import { Injectable } from '@angular/core';
 import { SessionService } from "../services/session.service";
+import { DataService } from "./data.service";
 
 @Injectable({
   providedIn: 'root'
 })
 export class PermissionService {
 
-  constructor(private sessionService: SessionService) {
+  constructor(private sessionService: SessionService, private dataService: DataService) {
+  }
+
+  async updatePermissions() {
+    const permittedActions = await this.dataService.getPermittedActions();
+    this.sessionService.setPermittedActions(permittedActions);
   }
 
   isUserPermitted(actionKey: string) {


### PR DESCRIPTION
In the bugfix, we solved an issue where a user who logged in in the old frontend didn't have permissions in the new frontend, because those were only set when logging in in the new frontend.